### PR TITLE
Hide any sprinklers that have been marked as disabled.

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ module.exports = function (homebridge) {
 
       config.pollIntervalMs = config.pollIntervalMs || 5000
       config.defaultDurationSecs = config.defaultDurationSecs || 600
-      config.enabledStationIds = config.enabledStationIds || [0,1,2,3]
+
       if (!config.host) {
         throw("Host must be specified in the configuration!")
       }
@@ -57,4 +57,3 @@ module.exports = function (homebridge) {
   homebridge.registerPlatform(PLATFORM_NAME, SprinklerPlatform);
 
 };
-

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -214,7 +214,7 @@ function DevicesModule(config, log, openSprinklerApi, Service, Characteristic) {
 
       // Each bit field represents 8 sprinklers, and the API gives us as many
       // as needed to cover them all. Bit field 0 will cover sprinklers 1-8,
-      // bit field 2 will cover sprinklers 9-16, and so on. We'll put them all
+      // bit field 1 will cover sprinklers 9-16, and so on. We'll put them all
       // into one array so that the indices will correspond to those in the
       // `snames` array.
       this.disabledSprinklers = [];

--- a/lib/devices.js
+++ b/lib/devices.js
@@ -26,6 +26,12 @@ function DevicesModule(config, log, openSprinklerApi, Service, Characteristic) {
     }
   }
 
+  // Converts an LSB bit field into an 8-item array with ones and zeroes. First
+  // array item corresponds to station 0, second to station 1, et cetera.
+  function flagsFromBitField (field) {
+    return [...Array(8)].map((x, i) => (field >> i) & 1);
+  }
+
   /** Tracks poll updates; if no update after threshold, throw errors */
   class PollUpdateTracker {
     constructor(name) {
@@ -205,9 +211,27 @@ function DevicesModule(config, log, openSprinklerApi, Service, Characteristic) {
 
       // Create all the sub-sprinklers
       this.masterStations = [systemStatus.options.mas, systemStatus.options.mas2]
+
+      // Each bit field represents 8 sprinklers, and the API gives us as many
+      // as needed to cover them all. Bit field 0 will cover sprinklers 1-8,
+      // bit field 2 will cover sprinklers 9-16, and so on. We'll put them all
+      // into one array so that the indices will correspond to those in the
+      // `snames` array.
+      this.disabledSprinklers = [];
+      for (let i = 0; i < systemStatus.stations.stn_dis.length; i++) {
+        let bitField = systemStatus.stations.stn_dis[i];
+        this.disabledSprinklers.push(...flagsFromBitField(bitField));
+      }
+
       this.sprinklers = []
       for (let i = 0; i < systemStatus.stations.snames.length; i++) {
-        this.sprinklers.push(new SprinklerStation(systemStatus.stations.snames[i], i + 1))
+        let name = systemStatus.stations.snames[i];
+        // Skip any sprinkler whose disabled flag is set to 1.
+        if (this.disabledSprinklers[i] === 1) {
+          log(`Skipping ${name}; marked as disabled`);
+          continue;
+        }
+        this.sprinklers.push(new SprinklerStation(name, i + 1))
       }
     }
 


### PR DESCRIPTION
I've marked five stations as disabled in OpenSprinkler, and I didn't want them to show up in the HomeKit UI. I noticed that this fork eliminated the `enabledStationIds` option in config, but didn't replace it with anything.

I dug into the API docs for the OpenSprinkler firmware to find how it reports which sprinklers are disabled, then wrote some code to refrain from adding any sprinkler that OS tells us is disabled. That way there's no need for a separate config option in the first place.

This works on my system — one controller, no expansion boards. I've written the code so that, by my understanding, it'll work for an arbitrary number of sprinklers, but I've got no way of testing that.